### PR TITLE
Fix issue with Folium v0.15.0 re. adding layers to map

### DIFF
--- a/folium_glify_layer/__init__.py
+++ b/folium_glify_layer/__init__.py
@@ -95,6 +95,7 @@ class GlifyLayer(JSCSSMixin, Layer):
     _template = Template(u"""
         {% macro script(this, kwargs) %}
 
+        var {{ this.get_name() }} = (function() {
             var map = {{ this._parent.get_name() }};
            
             var options = {
@@ -201,9 +202,10 @@ class GlifyLayer(JSCSSMixin, Layer):
                 };
 
             {%- endif %}
-            
-            
-            L.glify.layer(options).addTo({{ this._parent.get_name() }});          
+
+            return L.glify.layer(options);
+        
+        })();
 
         {% endmacro %}
         """)


### PR DESCRIPTION
In Folium v0.15.0 we added a change in how layers are added to the map. This broke things here in this plugin. See https://github.com/python-visualization/folium/pull/1690.

Fix it by not adding the layer to the map on initialization, but let the Layer class take care of that.

In addition, I opted to put the logic in a function so variable names like `map` and `options` don't interfere with other scopes.